### PR TITLE
feat: install GitHub Copilot (again)

### DIFF
--- a/lua/plugins/astrocore.lua
+++ b/lua/plugins/astrocore.lua
@@ -14,7 +14,7 @@ return {
     features = {
       large_buf = { size = 1024 * 256, lines = 10000 }, -- set global limits for large files for disabling features like treesitter
       autopairs = true, -- enable autopairs at start
-      cmp = true, -- enable completion at start
+      cmp = false, -- enable completion at start
       diagnostics = { virtual_text = true, virtual_lines = false }, -- diagnostic settings on startup
       highlighturl = true, -- highlight URLs at start
       notifications = true, -- enable notifications at start

--- a/lua/plugins/copilot.lua
+++ b/lua/plugins/copilot.lua
@@ -1,0 +1,3 @@
+return {
+  "github/copilot.vim"
+}


### PR DESCRIPTION
- Install GitHub Copilot for Neovim (copilot.vim).
- Disable completion that AstroNvim ships by default.